### PR TITLE
refresh the link to cvs (for the aug15 commit)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -36,7 +36,7 @@ $(".video-item a").click(function(event) {
 // CSV handling 
 $.ajax({
 	// alt URL: https://rawgit.com/bellaratmelia/limchongyah/master/lcy_news.csv
-    url: "https://cdn.rawgit.com/bellaratmelia/limchongyah/4caea731/lcy_news.csv",
+    url: "https://cdn.rawgit.com/bellaratmelia/limchongyah/954f8d77/lcy_news.csv",
     async: true,
     success: function (csvd) {
         items = $.csv.toObjects(csvd);


### PR DESCRIPTION
I forgot to edit the js for the Aug15 commit. This should load the newest csv with the changes made during that Aug15 commit that was done to fix the newspaperSG broken links.